### PR TITLE
Fix caret position when displayTransform property is used.

### DIFF
--- a/lib/MentionsInput.js
+++ b/lib/MentionsInput.js
@@ -492,10 +492,17 @@ module.exports = React.createClass({
     var end = start + querySequenceEnd - querySequenceStart;
     var insert = utils.makeMentionsMarkup(this.props.markup, suggestion.id, suggestion.display, mentionDescriptor.props.type);
     var newValue = utils.spliceString(value, start, end, insert);
+    var displayValue = utils.applyChangeToValue(
+      value, this.props.markup,
+      suggestion.display,
+      this.state.selectionStart, this.state.selectionEnd,
+      this.state.selectionEnd,
+      this.props.displayTransform
+    );
 
     // Refocus input and set caret position to end of mention
     this.refs.input.getDOMNode().focus();
-    var newCaretPosition = querySequenceStart + suggestion.display.length;
+    var newCaretPosition = querySequenceStart + displayValue.length;
     this.setState({
       selectionStart: newCaretPosition,
       selectionEnd: newCaretPosition


### PR DESCRIPTION
When `displayTransform` is used, the length of the string to get the position for the caret is not correct, since it's not `suggestion.display`.