### PR TITLE
Send the plainTextValue and mentions array arguments to the handleCha…

### DIFF
--- a/src/MentionsInput.jsx
+++ b/src/MentionsInput.jsx
@@ -548,7 +548,9 @@ module.exports = React.createClass({
     // Propagate change
     var handleChange = LinkedValueUtils.getOnChange(this) || emptyFunction;
     var eventMock = { target: { value: newValue }};
-    handleChange.call(this, eventMock, newValue);
+    var mentions = utils.getMentions(newValue, this.props.markup);
+    var plainTextValue = event.target.value
+    handleChange.call(this, eventMock, newValue, plainTextValue, mentions);
 
     var onAdd = mentionDescriptor.props.onAdd;
     if(onAdd) {


### PR DESCRIPTION
…nge callback when adding a new mention

Currently these arguments are `undefined` in my `handleChange` action, where on `keyDown` they are not. This means when a user's last input was inserting a mention, it is not realized until they do an additional `keyDown` action. This change mimics the behavior done on `keyDown`, and sends the additional function parameters.