### PR TITLE
Remove call to native event object

### DIFF
--- a/src/MentionsInput.jsx
+++ b/src/MentionsInput.jsx
@@ -488,7 +488,7 @@ module.exports = React.createClass({
       var match = substring.match(regex);
       if(match) {
         var querySequenceStart = substring.indexOf(match[1], match.index);
-        that.queryData(match[2], child, querySequenceStart, querySequenceStart+match[1].length);
+        that.queryData(match[2], child, querySequenceStart, querySequenceStart+match[1].length, plainTextValue);
       }
     });
   },
@@ -501,15 +501,15 @@ module.exports = React.createClass({
     });
   },
 
-  queryData: function(query, mentionDescriptor, querySequenceStart, querySequenceEnd) {
+  queryData: function(query, mentionDescriptor, querySequenceStart, querySequenceEnd, plainTextValue) {
     var provideData = _getDataProvider(mentionDescriptor.props.data);
-    var snycResult = provideData(query, this.updateSuggestions.bind(null, this._queryId, mentionDescriptor, query, querySequenceStart, querySequenceEnd));
+    var snycResult = provideData(query, this.updateSuggestions.bind(null, this._queryId, mentionDescriptor, query, querySequenceStart, querySequenceEnd, plainTextValue));
     if(snycResult instanceof Array) {
-      this.updateSuggestions(this._queryId, mentionDescriptor, query, querySequenceStart, querySequenceEnd, snycResult);
+      this.updateSuggestions(this._queryId, mentionDescriptor, query, querySequenceStart, querySequenceEnd, plainTextValue, snycResult);
     }
   },
 
-  updateSuggestions: function(queryId, mentionDescriptor, query, querySequenceStart, querySequenceEnd, suggestions) {
+  updateSuggestions: function(queryId, mentionDescriptor, query, querySequenceStart, querySequenceEnd, plainTextValue, suggestions) {
     // neglect async results from previous queries
     if(queryId !== this._queryId) return;
 
@@ -519,7 +519,8 @@ module.exports = React.createClass({
       mentionDescriptor: mentionDescriptor,
       querySequenceStart: querySequenceStart,
       querySequenceEnd: querySequenceEnd,
-      results: suggestions
+      results: suggestions,
+      plainTextValue: plainTextValue
     };
 
     this.setState({
@@ -527,7 +528,7 @@ module.exports = React.createClass({
     });
   },
 
-  addMention: function(suggestion, mentionDescriptor, querySequenceStart, querySequenceEnd) {
+  addMention: function(suggestion, mentionDescriptor, querySequenceStart, querySequenceEnd, plainTextValue) {
     // Insert mention in the marked up value at the correct position
     var value = LinkedValueUtils.getValue(this) || "";
     var start = utils.mapPlainTextIndex(value, this.props.markup, querySequenceStart, false, this.props.displayTransform);
@@ -549,8 +550,8 @@ module.exports = React.createClass({
     var handleChange = LinkedValueUtils.getOnChange(this) || emptyFunction;
     var eventMock = { target: { value: newValue }};
     var mentions = utils.getMentions(newValue, this.props.markup);
-    var plainTextValue = event.target.value
-    handleChange.call(this, eventMock, newValue, plainTextValue, mentions);
+    var newPlainTextValue = utils.spliceString(plainTextValue, querySequenceStart, querySequenceEnd, displayValue);
+    handleChange.call(this, eventMock, newValue, newPlainTextValue, mentions);
 
     var onAdd = mentionDescriptor.props.onAdd;
     if(onAdd) {

--- a/src/SuggestionsOverlay.jsx
+++ b/src/SuggestionsOverlay.jsx
@@ -48,7 +48,8 @@ module.exports = React.createClass({
           this.renderSuggestion(
             suggestions.results[i], suggestions.query,
             suggestions.querySequenceStart, suggestions.querySequenceEnd,
-            suggestions.mentionDescriptor, listItems.length
+            suggestions.mentionDescriptor, listItems.length,
+            suggestions.plainTextValue
           )
         );
       }
@@ -56,7 +57,7 @@ module.exports = React.createClass({
     return listItems;
   },
 
-  renderSuggestion: function(suggestion, query, querySequenceStart, querySequenceEnd, mentionDescriptor, index) {
+  renderSuggestion: function(suggestion, query, querySequenceStart, querySequenceEnd, mentionDescriptor, index, plainTextValue) {
     var id, display;
     var type = mentionDescriptor.props.type;
 
@@ -71,7 +72,7 @@ module.exports = React.createClass({
 
     var isFocused = (index === this.state.focusIndex);
     var cls = isFocused ? "focus" : "";
-    var handleClick = this.select.bind(null, suggestion, mentionDescriptor, querySequenceStart, querySequenceEnd);
+    var handleClick = this.select.bind(null, suggestion, mentionDescriptor, querySequenceStart, querySequenceEnd, plainTextValue);
 
     var highlightedDisplay = this.renderHighlightedDisplay(display, query);
     var content = mentionDescriptor.props.renderSuggestion ?
@@ -104,8 +105,8 @@ module.exports = React.createClass({
     });
   },
 
-  select: function(suggestion, mentionDescriptor, querySequenceStart, querySequenceEnd) {
-    this.props.onSelect(suggestion, mentionDescriptor, querySequenceStart, querySequenceEnd);
+  select: function(suggestion, mentionDescriptor, querySequenceStart, querySequenceEnd, plainTextValue) {
+    this.props.onSelect(suggestion, mentionDescriptor, querySequenceStart, querySequenceEnd, plainTextValue);
   },
 
   selectFocused: function() {


### PR DESCRIPTION
Relying on the native event object is unreliable, and fails in firefox. this pr adds the necessary plumbing to provide the plainTextValue to the onChange callback when referenced in addMention, by passing it through the suggestion.