### PR TITLE
prevent suggestions being clipped by window

### DIFF
--- a/src/MentionsInput.jsx
+++ b/src/MentionsInput.jsx
@@ -445,7 +445,13 @@ module.exports = React.createClass({
     var highligherEl = this.refs.highlighter.getDOMNode();
     if(!suggestionsEl) return;
 
-    suggestionsEl.style.left = caretEl.offsetLeft - highligherEl.scrollLeft + "px";
+    var leftPos = caretEl.offsetLeft - highligherEl.scrollLeft;
+    // guard for mentions suggestions list clipped by right edge of window
+    if (leftPos + suggestionsEl.offsetWidth > window.innerWidth) {
+      suggestionsEl.style.right = "0px"
+    } else {
+      suggestionsEl.style.left = leftPos + "px"
+    }
     suggestionsEl.style.top = caretEl.offsetTop - highligherEl.scrollTop + "px";
   },
 


### PR DESCRIPTION
## The problem
There's no check guaranteeing that there's enough space in window to display the suggestions list, so it can easily be cut off by window, especially on mobile:
![screen shot 2015-08-27 at 14 01 27](https://cloud.githubusercontent.com/assets/7192832/9521475/fa7048ac-4cc6-11e5-9358-2fbd7146bfc5.png)

## The fix
I just check if suggestions would be displayed partially outside of window, if so I display them from right hand side of window and inwards instead. Works, although you might want a different solution.
![screen shot 2015-08-27 at 14 04 18](https://cloud.githubusercontent.com/assets/7192832/9521506/330eea4c-4cc7-11e5-8969-2b6da1a6b1fb.png)

