### PR TITLE
Pass payload to custom suggestion render

### DIFF
--- a/lib/SuggestionsOverlay.js
+++ b/lib/SuggestionsOverlay.js
@@ -77,7 +77,7 @@ module.exports = React.createClass({
 
     var highlightedDisplay = this.renderHighlightedDisplay(display, query);
     var content = mentionDescriptor.props.renderSuggestion ?
-      mentionDescriptor.props.renderSuggestion(id, display, query, highlightedDisplay) :
+      mentionDescriptor.props.renderSuggestion(id, display, query, highlightedDisplay, suggestion) :
       highlightedDisplay;
 
     return (


### PR DESCRIPTION
Hi!

I wanted to render the suggestion with a thumbnail, that was part of the search result payload, but not being passed to the custom `renderSuggestion` call.

Resolved this passing the `suggestion` as a last parameter.

Opening this PR in case you want to merge it in :+1: 