### PR TITLE
Removing react-dom dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "mocha": "1.20.1",
     "mversion": "^1.10.0",
     "react": "~0.14.0",
-    "react-dom": "~0.14.0",
     "react-hot-loader": "^1.2.5",
     "react-router": "^1.0.0-rc3",
     "react-tools": "~0.14.0-alpha3",

--- a/src/MentionsInput.jsx
+++ b/src/MentionsInput.jsx
@@ -1,5 +1,4 @@
 var React = require('react');
-var ReactDOM = require('react-dom');
 var LinkedValueUtils = require('react/lib/LinkedValueUtils');
 var emptyFunction = require('fbjs/lib/emptyFunction');
 
@@ -453,7 +452,7 @@ module.exports = React.createClass({
 
     var containerEl = this.refs.container;
     var caretEl = this.refs.caret;
-    var suggestionsEl = ReactDOM.findDOMNode(this.refs.suggestions);
+    var suggestionsEl = React.findDOMNode(this.refs.suggestions);
     var highligherEl = this.refs.highlighter;
     if(!suggestionsEl) return;
 


### PR DESCRIPTION
MentionsInput.jsx requires react-dom but react-dom is only listed as a devDependency
which causes projects that use react-mentions to have react-dom in their dependencies list.

React 0.14 provides React.findDOMNode() which is all react-dom was used for in this project.