### PR TITLE
Remove value prop of `input` or `textarea`

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -128,8 +128,6 @@ const MentionsInput = React.createClass({
 
       ...substyle(this.props, getModifiers(this.props, "input")),
 
-      value: this.getPlainText(),
-
       ...(!readOnly && !disabled && {
         onChange: this.handleChange,
         onSelect: this.handleSelect,


### PR DESCRIPTION
React has a problem that when you edit text asynchronously, the caret will jump to the end.
This may happen if you are modifying a controlled input component.

e.g. https://github.com/facebook/react/issues/2047

One solution is:

> add a ref, mutate the ref's value to the manipulated one, then update the state.

It's not clean but works.

So I suggest not to use controlled input/textarea component.