### PR TITLE
Add space-tail after mention markup.

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -545,13 +545,13 @@ const MentionsInput = React.createClass({
     var value = LinkedValueUtils.getValue(this.props) || "";
     var start = utils.mapPlainTextIndex(value, this.props.markup, querySequenceStart, false, this.props.displayTransform);
     var end = start + querySequenceEnd - querySequenceStart;
-    var insert = utils.makeMentionsMarkup(this.props.markup, suggestion.id, suggestion.display, mentionDescriptor.props.type);
+    var insert = utils.makeMentionsMarkup(this.props.markup, suggestion.id, suggestion.display, mentionDescriptor.props.type) + ' ';
     var newValue = utils.spliceString(value, start, end, insert);
 
     // Refocus input and set caret position to end of mention
     this.refs.input.focus();
 
-    var displayValue = this.props.displayTransform(suggestion.id, suggestion.display, mentionDescriptor.props.type);
+    var displayValue = this.props.displayTransform(suggestion.id, suggestion.display, mentionDescriptor.props.type) + ' ';
     var newCaretPosition = querySequenceStart + displayValue.length;
     this.setState({
       selectionStart: newCaretPosition,


### PR DESCRIPTION
For better user experience.

Without space-tail, user can not input mention markup continuously:

![original](https://cloud.githubusercontent.com/assets/3861465/14097001/b4bde26a-f59f-11e5-8aaa-4032b8a104f8.gif)

With space-tail, they are satisfied :laughing: 

![latest](https://cloud.githubusercontent.com/assets/3861465/14097049/16e6bd86-f5a0-11e5-8c92-0e508d009faa.gif)


