### PR TITLE
fix/(MentionsInput): refresh suggestions queries inside of handleChange

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -295,6 +295,13 @@ const MentionsInput = React.createClass({
     var eventMock = { target: { value: newValue } };
     // this.props.onChange.call(this, eventMock, newValue, newPlainTextValue, mentions);
     this.executeOnChange(eventMock, newValue, newPlainTextValue, mentions);
+
+    // refresh suggestions queries
+    if(ev.target.selectionStart === ev.target.selectionEnd) {
+      this.updateMentionsQueries(this.refs.input.value, ev.target.selectionStart);
+    } else {
+      this.clearSuggestions();
+    }
   },
 
   // Handle input element's select event


### PR DESCRIPTION
I resolved the issue #114 with this commit, but I don't completely understand what the problem is or why this would fix it.

For some reason I have been able to change the value of the input element without triggering the mentions. 