### PR TITLE
Ignore blur events fired when the 'Done' button on iOS keyboard is pressed

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -377,16 +377,6 @@ const MentionsInput = React.createClass({
   },
 
   handleBlur: function(ev) {
-    // only reset selection if the mousedown happened on an element
-    // other than the suggestions overlay
-    if(!this._suggestionsMouseDown) {
-      this.setState({
-        selectionStart: null,
-        selectionEnd: null
-      });
-    };
-    this._suggestionsMouseDown = false;
-
     window.setTimeout(() => {
       this.updateHighlighterScroll();
     }, 1);


### PR DESCRIPTION
With a Japanese keyboard on iOS, characters are entered in duplicate when the "Done" button is pressed before selecting conversion candidates.

It's because the blur and focus events are fired consecutively by pressing the 'Done' button.

The `event.relatedTarget` returns `null` when "Done" is clicked, so I use it for detection.

#### Current (Characters are entered in duplicate)
![ios-done-button-current](https://cloud.githubusercontent.com/assets/86085/20419341/3eeb205e-ad99-11e6-9a39-eddfd4cb955b.gif)

#### Expected
![ios-done-button-fixed](https://cloud.githubusercontent.com/assets/86085/20419343/41cf2f36-ad99-11e6-92ca-5776cc9e5d25.gif)
