### PR TITLE
Fix unknow property index on li

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mentions",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "React mentions input",
   "main": "lib/index.js",
   "scripts": {

--- a/src/Suggestion.js
+++ b/src/Suggestion.js
@@ -10,6 +10,7 @@ class Suggestion extends Component {
   static propTypes = {
     id: PropTypes.string.isRequired,
     query: PropTypes.string.isRequired,
+    index: PropTypes.number.isRequired,
 
     suggestion: PropTypes.oneOfType([
       PropTypes.string,


### PR DESCRIPTION
Fix the 'unknown index property' error on the li as mentioned in #111 by adding index property as required on the Suggestion Component.

When the Suggestion Component gets rendered we use _.omit on the props and propTypes. 
By doing this we ignore the index property on the li tag.