### PR TITLE
Bugfix/on blur clicked suggestion flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The `MentionsInput` supports the following props for configuring the widget:
 | markup           | string                                                  | `'@[__display__](__id__)'` | A template string for the markup to use for mentions                                     |
 | singleLine       | boolean                                                 | `false`                    | Renders a single line text input instead of a textarea, if set to `true`                 |
 | displayTransform | function (id, display, type)                            | returns `display`          | Accepts a function for customizing the string that is displayed for a mention            |
-| onBlur           | function (event, isSuggestionsDropdownShowing)          | empty function             | Passes `true` as second argument if the blur was caused by a click on a suggestion       |
+| onBlur           | function (event, clickedSuggestion)          | empty function             | Passes `true` as second argument if the blur was caused by a mousedown on a suggestion       |
 
 
 Each data source is configured using a `Mention` component, which has the following props:

--- a/gh-pages/views/examples/AdvancedView.js
+++ b/gh-pages/views/examples/AdvancedView.js
@@ -36,6 +36,7 @@ module.exports = React.createClass({
         <MentionsInput
           value={this.state.value}
           onChange={this.handleChange}
+          onBlur={this.handleBlur}
           markup="{{__id__}}"
           style={style}
           displayTransform={this.transformDisplay}>
@@ -52,6 +53,12 @@ module.exports = React.createClass({
 
   handleAddMention: function (id, display) {
     console.log("Added mention of " + id);
+  },
+
+  handleBlur: function(ev, clickedOnSuggestion) {
+    if(!clickedOnSuggestion) {
+      console.log("finished editing");
+    }
   }
 
 });

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -377,23 +377,23 @@ const MentionsInput = React.createClass({
   },
 
   handleBlur: function(ev) {
+    const clickedSuggestion = this._suggestionsMouseDown
+    this._suggestionsMouseDown = false;
+
     // only reset selection if the mousedown happened on an element
     // other than the suggestions overlay
-    if(!this._suggestionsMouseDown) {
+    if(!clickedSuggestion) {
       this.setState({
         selectionStart: null,
         selectionEnd: null
       });
     };
-    this._suggestionsMouseDown = false;
 
     window.setTimeout(() => {
       this.updateHighlighterScroll();
     }, 1);
 
-    // do not intercept key events if the suggestions overlay is not shown
-    const suggestionsShown = utils.countSuggestions(this.state.suggestions) > 0;
-    this.props.onBlur(ev, suggestionsShown);
+    this.props.onBlur(ev, clickedSuggestion);
   },
 
   handleSuggestionsMouseDown: function(ev) {


### PR DESCRIPTION
The flag passed as second arg to an `onBlur` handler was not indicating whether the click happened on a suggestion (as stated by the docs), but only that the suggestions overlay was open.