### PR TITLE
Position Suggestions Above Caret

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -59,6 +59,7 @@ const MentionsInput = React.createClass({
      * instead of a textarea
      */
     singleLine: PropTypes.bool,
+    positionSuggestionsAboveCaret: PropTypes.bool,
 
     markup: PropTypes.string,
     value: PropTypes.string,
@@ -411,7 +412,6 @@ const MentionsInput = React.createClass({
 
     let suggestions = ReactDOM.findDOMNode(this.refs.suggestions);
     let highlighter = ReactDOM.findDOMNode(this.refs.highlighter);
-
     if(!suggestions) {
       return;
     }
@@ -426,7 +426,13 @@ const MentionsInput = React.createClass({
       position.left = left
     }
 
-    position.top = caretPosition.top - highlighter.scrollTop;
+    if(this.props.positionSuggestionsAboveCaret) {
+      position.top = caretPosition.top - suggestions.scrollHeight;
+      position.marginTop = "0px";
+      position.marginBottom = "14px";
+    } else {
+      position.top = caretPosition.top - highlighter.scrollTop;
+    }
 
     if(isEqual(position, this.state.suggestionsPosition)) {
       return;

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -78,6 +78,7 @@ const MentionsInput = React.createClass({
 
   getDefaultProps: function () {
     return {
+      positionSuggestionsAboveCaret: false,
       markup: "@[__display__](__id__)",
       singleLine: false,
       displayTransform: function(id, display, type) {


### PR DESCRIPTION
In order to display a textbox on the bottom of the browser window we needed a way to position the suggestions overlay above the caret in a textarea or input.

![screen shot 2016-11-30 at 5 06 56 pm](https://cloud.githubusercontent.com/assets/2461547/20810620/36013476-b7bf-11e6-9b69-23c16094e391.png)
Notice the scroll bar is not supposed to be there and the text box is normally fixed to the bottom of the window.

We introduce the optional positionSuggestionsAboveCaret prop to MentionsInput which is default to false. It is backwards compatible because false causes the existing behavior to be executed. 

When true the bottom of the suggestions overlay will be above the caret. 