### PR TITLE
remove \\s from regex

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -21,7 +21,7 @@ var _getTriggerRegex = function(trigger) {
 
     // first capture group is the part to be replaced on completion
     // second capture group is for extracting the search query
-    return new RegExp("(?:^|\\s)(" + escapedTriggerChar + "([^\\s" + escapedTriggerChar + "]*))$");
+    return new RegExp("(?:^|\\s)(" + escapedTriggerChar + "([^" + escapedTriggerChar + "]*))$");
   }
 };
 


### PR DESCRIPTION
If I had many (100+ lets say)  users with the last name "Smith" and I'm truncating the list to only the top 10 matches then I'd need to specify a first name if I ever hope to complete my intended action.

So the type ahead can match for either "Walter White" or "Walter Smith" or anything that includes a space.

I have thousands of matches with the same first word.