### PR TITLE
Type on suggestions

### DIFF
--- a/gh-pages/views/ExamplesView.js
+++ b/gh-pages/views/ExamplesView.js
@@ -8,31 +8,36 @@ var Advanced = require("./examples/AdvancedView");
 var users = [
   {
     id: "walter",
-    display: "Walter White"
+    display: "Walter White",
+    type: "user"
   },
   {
     id: "jesse",
-    display: "Jesse Pinkman"
+    display: "Jesse Pinkman",
+    type: "user"
   },
   {
     id: "gus",
-    display: "Gustavo \"Gus\" Fring"
+    display: "Gustavo \"Gus\" Fring",
   },
   {
     id: "saul",
-    display: "Saul Goodman"
+    display: "Saul Goodman",
+    type: "admin"
   },
   {
     id: "hank",
-    display: "Hank Schrader"
+    display: "Hank Schrader",
+    type: "admin"
   },
   {
     id: "skyler",
-    display: "Skyler White"
+    display: "Skyler White",
+    type: "admin"
   },
   {
     id: "mike",
-    display: "Mike Ehrmantraut"
+    display: "Mike Ehrmantraut",
   }
 ];
 

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -21,7 +21,7 @@ var _getTriggerRegex = function(trigger) {
 
     // first capture group is the part to be replaced on completion
     // second capture group is for extracting the search query
-    return new RegExp("(?:^|\\s)(" + escapedTriggerChar + "([^" + escapedTriggerChar + "]*))$");
+    return new RegExp("(?:^|\\s)(" + escapedTriggerChar + "([^\\s" + escapedTriggerChar + "]*))$");
   }
 };
 


### PR DESCRIPTION
If type prop isn't defined for Mention check for the type property on suggestions. This is useful when the same trigger will match a variety of data types. This is backwards compatible.