### PR TITLE
Add "allowSpaceInQuery" prop

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -500,20 +500,19 @@ class MentionsInput extends React.Component {
     // Match the trigger patterns of all Mention children the new plain text substring up to the current caret position
     const substring = plainTextValue.substring(0, caretPosition);
 
-    const that = this;
-    React.Children.forEach(this.props.children, function(child) {
-      if(!child) {
-        return;
+    React.Children.forEach(this.props.children, child => {
+      if (!child) {
+        return
       }
 
-      const regex = _getTriggerRegex(child.props.trigger, that.props);
-      const match = substring.match(regex);
-      if(match) {
-        const querySequenceStart = substring.indexOf(match[1], match.index);
-        that.queryData(match[2], child, querySequenceStart, querySequenceStart+match[1].length, plainTextValue);
+      const regex = _getTriggerRegex(child.props.trigger, this.props)
+      const match = substring.match(regex)
+      if (match) {
+        const querySequenceStart = substring.indexOf(match[1], match.index)
+        this.queryData(match[2], child, querySequenceStart, querySequenceStart+match[1].length, plainTextValue)
       }
-    });
-  };
+    })
+  }
 
   clearSuggestions = () => {
     // Invalidate previous queries. Async results for previous queries will be neglected.

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -13,17 +13,18 @@ import utils from './utils';
 import SuggestionsOverlay from './SuggestionsOverlay';
 import Highlighter from './Highlighter';
 
-const _getTriggerRegex = function(trigger) {
-  if(trigger instanceof RegExp) {
-    return trigger;
+export const _getTriggerRegex = function(trigger, options={}) {
+  if (trigger instanceof RegExp) {
+    return trigger
   } else {
-    const escapedTriggerChar = utils.escapeRegex(trigger);
+    const { allowSpaceInQuery } = options
+    const escapedTriggerChar = utils.escapeRegex(trigger)
 
     // first capture group is the part to be replaced on completion
     // second capture group is for extracting the search query
-    return new RegExp("(?:^|\\s)(" + escapedTriggerChar + "([^\\s" + escapedTriggerChar + "]*))$");
+    return new RegExp(`(?:^|\\s)(${escapedTriggerChar}([^${allowSpaceInQuery ? '' : '\\s'}${escapedTriggerChar}]*))$`)
   }
-};
+}
 
 const _getDataProvider = function(data) {
   if(data instanceof Array) {
@@ -55,6 +56,11 @@ class MentionsInput extends React.Component {
      * instead of a textarea
      */
     singleLine: PropTypes.bool,
+
+    /**
+     * If set to `true` spaces will not interrupt matching suggestions
+     */
+    allowSpaceInQuery: PropTypes.bool,
 
     markup: PropTypes.string,
     value: PropTypes.string,
@@ -500,7 +506,7 @@ class MentionsInput extends React.Component {
         return;
       }
 
-      const regex = _getTriggerRegex(child.props.trigger);
+      const regex = _getTriggerRegex(child.props.trigger, that.props);
       const match = substring.match(regex);
       if(match) {
         const querySequenceStart = substring.indexOf(match[1], match.index);

--- a/test/MentionsInput.spec.js
+++ b/test/MentionsInput.spec.js
@@ -3,6 +3,7 @@ import { expect } from "chai";
 import { mount } from "enzyme";
 
 import { MentionsInput, Mention } from "../src";
+import { _getTriggerRegex } from "../src/MentionsInput";
 
 const data = [
     { id: "first", value: "First entry" },
@@ -15,7 +16,7 @@ describe("MentionsInput", () => {
 
     beforeEach(() => {
         node = mount(
-            <MentionsInput>
+            <MentionsInput value="">
                 <Mention
                     trigger="@"
                     data={ data } />
@@ -60,6 +61,23 @@ describe("MentionsInput", () => {
         })
 
         expect(wrapper.find('SuggestionsOverlay').find('Suggestion')).to.have.length(4)
+    })
+
+    describe("_getTriggerRegex", () => {
+        it("should return regular expressions", () => {
+            const trigger = /abc/
+            expect(_getTriggerRegex(trigger)).to.equal(trigger)
+        })
+
+        it("should escape and capture a string trigger", () => {
+            const result = _getTriggerRegex("trigger").toString()
+            expect(result).to.equal("/(?:^|\\s)(trigger([^\\strigger]*))$/")
+        })
+
+        it("should allow spaces in search", () => {
+            const result = _getTriggerRegex("trigger", {allowSpaceInQuery: true}).toString()
+            expect(result).to.equal("/(?:^|\\s)(trigger([^trigger]*))$/")
+        })
     })
 
 });


### PR DESCRIPTION
As requested by @frontendphil, here is the `allowSpaceInQuery` prop to toggle the behavior from #133 

- Tweaks the trigger regex if the prop is true to allow spaces when matching suggestions
- Touch-ups to the surrounding method body to reduce lint warnings
- Adds unit tests to cover the changes
- Set `value=""` to remove a console warning when running tests