### PR TITLE
adds spellCheck, sets it to PLAIN_TEXT by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The `MentionsInput` supports the following props for configuring the widget:
 | displayTransform | function (id, display, type)                            | returns `display`          | Accepts a function for customizing the string that is displayed for a mention            |
 | onBlur           | function (event, clickedSuggestion)          | empty function             | Passes `true` as second argument if the blur was caused by a mousedown on a suggestion       |
 | allowSpaceInQuery | boolean               | false           | Keep suggestions open even if the user separates keywords with spaces. |
+| spellCheck | boolean | 'PLAIN_TEXT' | 'PLAIN_TEXT' | Enable spell check always (true), never (false), or only when there are no mentions ('PLAIN_TEXT') |
 
 Each data source is configured using a `Mention` component, which has the following props:
 

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -13,6 +13,8 @@ import utils from './utils';
 import SuggestionsOverlay from './SuggestionsOverlay';
 import Highlighter from './Highlighter';
 
+console.log('hi')
+
 export const _getTriggerRegex = function(trigger, options={}) {
   if (trigger instanceof RegExp) {
     return trigger
@@ -74,7 +76,9 @@ class MentionsInput extends React.Component {
     children: PropTypes.oneOfType([
       PropTypes.element,
       PropTypes.arrayOf(PropTypes.element),
-    ]).isRequired
+    ]).isRequired,
+
+    spellCheck: PropTypes.oneOf([true, false, 'PLAIN_TEXT']),
   };
 
   static defaultProps = {
@@ -85,7 +89,8 @@ class MentionsInput extends React.Component {
     },
     onKeyDown: () => null,
     onSelect: () => null,
-    onBlur: () => null
+    onBlur: () => null,
+    spellCheck: 'PLAIN_TEXT',
   };
 
   constructor(props) {
@@ -115,16 +120,20 @@ class MentionsInput extends React.Component {
   }
 
   getInputProps = (isTextarea) => {
-    let { readOnly, disabled, style } = this.props;
+    let { readOnly, disabled, style, spellCheck, value } = this.props;
 
     // pass all props that we don't use through to the input control
     let props = omit(this.props, 'style', keys(MentionsInput.propTypes));
+
+    let spellCheckProp = !!spellCheck;
+    if (spellCheck === 'PLAIN_TEXT') spellCheckProp = this.getPlainText() === value;
 
     return {
       ...props,
       ...style("input"),
 
       value: this.getPlainText(),
+      spellCheck: spellCheckProp,
 
       ...(!readOnly && !disabled && {
         onChange: this.handleChange,
@@ -133,7 +142,7 @@ class MentionsInput extends React.Component {
         onBlur: this.handleBlur,
         onCompositionStart: this.handleCompositionStart,
         onCompositionEnd: this.handleCompositionEnd,
-      })
+      }),
     };
   };
 

--- a/test/MentionsInput.spec.js
+++ b/test/MentionsInput.spec.js
@@ -80,4 +80,43 @@ describe("MentionsInput", () => {
         })
     })
 
+    describe("spellCheck", () => {
+        it("should render when input is plain text", () => {
+            const wrapper = mount(
+                <MentionsInput value="@" value="Example text" markup="{{__id__}}">
+                    <Mention trigger="@" type="testentries" data={data} />
+                </MentionsInput>
+            )
+
+            expect(wrapper.find('textarea').prop('spellCheck')).to.equal(true);
+        });
+        it("should render when input is plain text", () => {
+            const wrapper = mount(
+                <MentionsInput value="@" value="Example text {{__29409189109__}} with id" markup="{{__id__}}">
+                    <Mention trigger="@" type="testentries" data={data} />
+                </MentionsInput>
+            )
+
+            expect(wrapper.find('textarea').prop('spellCheck')).to.equal(false);
+        });
+        it("should work with hard coded true", () => {
+            const wrapper = mount(
+                <MentionsInput value="@" value="Example text {{__29409189109__}} with id" markup="{{__id__}}" spellCheck={true}>
+                    <Mention trigger="@" type="testentries" data={data} />
+                </MentionsInput>
+            )
+
+            expect(wrapper.find('textarea').prop('spellCheck')).to.equal(true);
+        });
+
+        it("should work with hard coded false", () => {
+            const wrapper = mount(
+                <MentionsInput value="@" value="Example text" markup="{{__id__}}" spellCheck={false}>
+                    <Mention trigger="@" type="testentries" data={data} />
+                </MentionsInput>
+            )
+
+            expect(wrapper.find('textarea').prop('spellCheck')).to.equal(false);
+        });
+    })
 });


### PR DESCRIPTION
It's weird when there are mentions or hashtags and the browser's spell check flags them. We can't disable it for specific text ranges in the input, so this is the best strategy I could come up with:

When there's plain text (no mentions), spell check is enabled. When there's a mention, spell check is disabled. The user can override it with an explicit `spellCheck={true}` or `spellCheck={false}`.

Defaulting to the automatic check for mentions existing seems the most intuitive, but I can see arguments against it.

