### PR TITLE
fix for #189

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -223,7 +223,7 @@ module.exports = {
     var mentionStart = this.findStartOfMentionInPlainText(value, markup, indexInPlainText, displayTransform);
     return mentionStart !== undefined && mentionStart !== indexInPlainText
   },
-  
+
   // Applies a change from the plain text textarea to the underlying marked up value
   // guided by the textarea text selection ranges before and after the change
   applyChangeToValue: function(value, markup, plainTextValue, selectionStartBeforeChange, selectionEndBeforeChange, selectionEndAfterChange, displayTransform) {
@@ -290,7 +290,7 @@ module.exports = {
         newValue = this.spliceString(value, mappedSpliceStart, mappedSpliceEnd, insert);
       }
     }
-    
+
     return newValue;
   },
 
@@ -309,7 +309,7 @@ module.exports = {
     });
   },
 
-  getMentions: function (value, markup) {
+  getMentions: function (value, markup, displayTransform) {
     var mentions = [];
     this.iterateMentionsMarkup(value, markup, function (){}, function (match, index, plainTextIndex, id, display, type, start) {
       mentions.push({
@@ -319,8 +319,16 @@ module.exports = {
         index: index,
         plainTextIndex: plainTextIndex
       });
-    });
+    }, displayTransform);
     return mentions;
+  },
+
+  getEndOfLastMention: function (value, markup, displayTransform) {
+    const mentions = this.getMentions(value, markup, displayTransform);
+    const lastMention = mentions[mentions.length - 1];
+    return lastMention ?
+      lastMention.plainTextIndex + lastMention.display.length :
+      0;
   },
 
   makeMentionsMarkup: function(markup, id, display, type) {

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -373,6 +373,31 @@ describe("utils", function() {
       ]);
     })
 
+    it('should take into account the displayTransform if passed', function () {
+      var mentions = utils.getMentions(value, defaultMarkup, displayTransform);
+      expect(mentions).to.deep.equal([
+        { id: "johndoe", display: "<--johndoe-->", type: "user", index: 3, plainTextIndex: 3 },
+        { id: "joe@smoe.com", display: "<--joe@smoe.com-->", type: "email", index: 42, plainTextIndex: 30 }
+      ]);
+    })
+
   });
+
+  describe('#getEndOfLastMention', () => {
+    it('should return the end index of the last mention in the plain text', () => {
+      var index = utils.getEndOfLastMention(value, defaultMarkup);
+      expect(index).to.equal(37);
+    })
+
+    it('should take into account the displayTransform', () => {
+      var index = utils.getEndOfLastMention(value, defaultMarkup, displayTransform);
+      expect(index).to.equal(48);
+    })
+
+    it('should return 0 if there is no mention', () => {
+      var index = utils.getEndOfLastMention('No mentions to be found here', defaultMarkup);
+      expect(index).to.equal(0);
+    })
+  })
 
 });


### PR DESCRIPTION
fixes a problem (#189) happening if existing mentions happen to be including in the matching sequence for a new mention, e.g. when keeping to type directly after an email mentions
