### PR TITLE
Make sure handleChange works within iframe

### DIFF
--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -235,7 +235,7 @@ class MentionsInput extends React.Component {
   // Handle input element's change event
   handleChange = (ev) => {
     // if we are inside iframe, we need to find activeElement within its contentDocument
-    const currentDocument = document.activeElement.contentDocument || document;
+    const currentDocument = (document.activeElement && document.activeElement.contentDocument) || document;
     if(currentDocument.activeElement !== ev.target) {
       // fix an IE bug (blur from empty input element with placeholder attribute trigger "input" event)
       return;

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -234,8 +234,9 @@ class MentionsInput extends React.Component {
 
   // Handle input element's change event
   handleChange = (ev) => {
-
-    if(document.activeElement !== ev.target) {
+    // if we are inside iframe, we need to find activeElement within its contentDocument
+    let currentDocument = document.activeElement.contentDocument || document
+    if(currentDocument.activeElement !== ev.target) {
       // fix an IE bug (blur from empty input element with placeholder attribute trigger "input" event)
       return;
     }

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -235,7 +235,7 @@ class MentionsInput extends React.Component {
   // Handle input element's change event
   handleChange = (ev) => {
     // if we are inside iframe, we need to find activeElement within its contentDocument
-    let currentDocument = document.activeElement.contentDocument || document
+    let currentDocument = document.activeElement.contentDocument || document;
     if(currentDocument.activeElement !== ev.target) {
       // fix an IE bug (blur from empty input element with placeholder attribute trigger "input" event)
       return;

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -235,7 +235,7 @@ class MentionsInput extends React.Component {
   // Handle input element's change event
   handleChange = (ev) => {
     // if we are inside iframe, we need to find activeElement within its contentDocument
-    let currentDocument = document.activeElement.contentDocument || document;
+    const currentDocument = document.activeElement.contentDocument || document;
     if(currentDocument.activeElement !== ev.target) {
       // fix an IE bug (blur from empty input element with placeholder attribute trigger "input" event)
       return;


### PR DESCRIPTION
When MentionsInput is inside an iframe, document.activeElement returns iframe itself instead of actual input, so we need to dig deeper in that case.