### PR TITLE
:sparkles: set autoFocus in textarea

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The `MentionsInput` supports the following props for configuring the widget:
 | displayTransform | function (id, display, type)                            | returns `display`          | Accepts a function for customizing the string that is displayed for a mention            |
 | onBlur           | function (event, clickedSuggestion)          | empty function             | Passes `true` as second argument if the blur was caused by a mousedown on a suggestion       |
 | allowSpaceInQuery | boolean               | false           | Keep suggestions open even if the user separates keywords with spaces. |
+autoFocus | boolean | false | Set `autoFocus` in textarea (optional)
 
 Each data source is configured using a `Mention` component, which has the following props:
 

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -64,6 +64,7 @@ class MentionsInput extends React.Component {
 
     markup: PropTypes.string,
     value: PropTypes.string,
+    autoFocus: PropTypes.bool,
 
     displayTransform: PropTypes.func,
     onKeyDown: PropTypes.func,
@@ -83,6 +84,7 @@ class MentionsInput extends React.Component {
     displayTransform: function(id, display, type) {
       return display;
     },
+    autoFocus: false,
     onKeyDown: () => null,
     onSelect: () => null,
     onBlur: () => null
@@ -115,7 +117,7 @@ class MentionsInput extends React.Component {
   }
 
   getInputProps = (isTextarea) => {
-    let { readOnly, disabled, style } = this.props;
+    let { readOnly, disabled, style, autoFocus } = this.props;
 
     // pass all props that we don't use through to the input control
     let props = omit(this.props, 'style', keys(MentionsInput.propTypes));
@@ -127,6 +129,7 @@ class MentionsInput extends React.Component {
       value: this.getPlainText(),
 
       ...(!readOnly && !disabled && {
+        autoFocus: autoFocus,
         onChange: this.handleChange,
         onSelect: this.handleSelect,
         onKeyDown: this.handleKeyDown,


### PR DESCRIPTION
## Issue 
In my project, text area is hidden and when I click a button I need to show textarea with auto focus

## Changes

Receive `autoFocus` from propTypes and set in textarea