### PR TITLE
Allow id to be an integer (#215)

### DIFF
--- a/src/Suggestion.js
+++ b/src/Suggestion.js
@@ -7,14 +7,14 @@ import keys from 'lodash/keys';
 class Suggestion extends Component {
 
   static propTypes = {
-    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     query: PropTypes.string.isRequired,
     index: PropTypes.number.isRequired,
 
     suggestion: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.shape({
-        id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
         display: PropTypes.string
       }),
     ]).isRequired,

--- a/src/Suggestion.js
+++ b/src/Suggestion.js
@@ -7,14 +7,14 @@ import keys from 'lodash/keys';
 class Suggestion extends Component {
 
   static propTypes = {
-    id: PropTypes.string.isRequired,
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     query: PropTypes.string.isRequired,
     index: PropTypes.number.isRequired,
 
     suggestion: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.shape({
-        id: PropTypes.string.isRequired,
+        id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
         display: PropTypes.string
       }),
     ]).isRequired,


### PR DESCRIPTION
Allow data.id to be an integer and not just string (#215).
Currently data.id pops warning when id is an integer (number).